### PR TITLE
feat: report errors to Sentry for api, worker and frontend

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@gouvfr/dsfr": "~1.14.3",
     "@gouvminint/vue-dsfr": "^8.14.0",
+    "@sentry/vue": "^10.7.0",
     "@tailwindcss/vite": "^4.1.18",
     "@vueuse/components": "^13.9.0",
     "axios": "^1.13.5",

--- a/apps/client/pnpm-lock.yaml
+++ b/apps/client/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@gouvminint/vue-dsfr':
         specifier: ^8.14.0
         version: 8.14.0(@iconify/vue@4.3.0(vue@3.5.28(typescript@5.9.3)))(vue-router@4.6.4(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
+      '@sentry/vue':
+        specifier: ^10.7.0
+        version: 10.58.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.2))
@@ -1297,6 +1300,43 @@ packages:
 
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
+
+  '@sentry/browser-utils@10.58.0':
+    resolution: {integrity: sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.58.0':
+    resolution: {integrity: sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.58.0':
+    resolution: {integrity: sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.58.0':
+    resolution: {integrity: sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay-canvas@10.58.0':
+    resolution: {integrity: sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.58.0':
+    resolution: {integrity: sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==}
+    engines: {node: '>=18'}
+
+  '@sentry/vue@10.58.0':
+    resolution: {integrity: sha512-He7h4rACaTBO6jrXEkJ19sDovgV52dJrzClYbdIbCjpLjiEhLYbKVU5YkrZt5/45wQvIy5GPqNGCn9aHxKFBqw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@tanstack/vue-router': ^1.64.0
+      pinia: 2.x || 3.x
+      vue: 2.x || 3.x
+    peerDependenciesMeta:
+      '@tanstack/vue-router':
+        optional: true
+      pinia:
+        optional: true
 
   '@stylistic/eslint-plugin@5.8.0':
     resolution: {integrity: sha512-WNPVF/FfBAjyi3OA7gok8swRiImNLKI4dmV3iK/GC/0xSJR7eCzBFsw9hLZVgb1+MYNLy7aDsjohxN1hA/FIfQ==}
@@ -5657,6 +5697,42 @@ snapshots:
     optional: true
 
   '@rushstack/eslint-patch@1.15.0': {}
+
+  '@sentry/browser-utils@10.58.0':
+    dependencies:
+      '@sentry/core': 10.58.0
+
+  '@sentry/browser@10.58.0':
+    dependencies:
+      '@sentry/browser-utils': 10.58.0
+      '@sentry/core': 10.58.0
+      '@sentry/feedback': 10.58.0
+      '@sentry/replay': 10.58.0
+      '@sentry/replay-canvas': 10.58.0
+
+  '@sentry/core@10.58.0': {}
+
+  '@sentry/feedback@10.58.0':
+    dependencies:
+      '@sentry/core': 10.58.0
+
+  '@sentry/replay-canvas@10.58.0':
+    dependencies:
+      '@sentry/core': 10.58.0
+      '@sentry/replay': 10.58.0
+
+  '@sentry/replay@10.58.0':
+    dependencies:
+      '@sentry/browser-utils': 10.58.0
+      '@sentry/core': 10.58.0
+
+  '@sentry/vue@10.58.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))':
+    dependencies:
+      '@sentry/browser': 10.58.0
+      '@sentry/core': 10.58.0
+      vue: 3.5.28(typescript@5.9.3)
+    optionalDependencies:
+      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3))
 
   '@stylistic/eslint-plugin@5.8.0(eslint@9.39.2(jiti@2.6.1))':
     dependencies:

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/vue'
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 
@@ -5,7 +6,7 @@ import { createApp } from 'vue'
 import VueMatomo from 'vue-matomo'
 import App from './App.vue'
 import router from './router/index'
-import { MATOMO_SITE_ID, MATOMO_SITE_URL } from './utils/constants'
+import { ENVIRONMENT, MATOMO_SITE_ID, MATOMO_SITE_URL, SENTRY_FRONTEND_DSN } from './utils/constants'
 import { keycloakInit } from './utils/keycloak'
 
 import '@gouvfr/dsfr/dist/core/core.main.min.css'
@@ -29,7 +30,23 @@ async function initializeApp () {
     await keycloakInit()
   }
 
-  createApp(App)
+  const app = createApp(App)
+
+  if (SENTRY_FRONTEND_DSN) {
+    try {
+      Sentry.init({
+        app,
+        dsn: SENTRY_FRONTEND_DSN,
+        environment: ENVIRONMENT,
+        sendDefaultPii: false,
+      })
+    }
+    catch (e) {
+      console.error('Sentry initialization failed, continuing without it:', e)
+    }
+  }
+
+  app
     .use(createPinia())
     .use(router)
     .use(VueMatomo, {

--- a/apps/client/src/utils/constants.ts
+++ b/apps/client/src/utils/constants.ts
@@ -22,3 +22,6 @@ export const USER_REVIEW_URL = (window as any).VITE_USER_REVIEW_URL ?? import.me
 export const TCHAP_CANAL_URL = (window as any).VITE_TCHAP_CANAL_URL ?? import.meta.env.VITE_TCHAP_CANAL_URL
 export const CHAT_URL = (window as any).VITE_CHAT_URL ?? import.meta.env.VITE_CHAT_URL
 export const PORTAIL_URL = (window as any).VITE_PORTAIL_URL ?? import.meta.env.VITE_PORTAIL_URL
+
+export const SENTRY_FRONTEND_DSN = (window as any).VITE_SENTRY_FRONTEND_DSN ?? import.meta.env.VITE_SENTRY_FRONTEND_DSN
+export const ENVIRONMENT = (window as any).VITE_ENVIRONMENT ?? import.meta.env.VITE_ENVIRONMENT

--- a/apps/server/ocr_backend/main.py
+++ b/apps/server/ocr_backend/main.py
@@ -1,3 +1,6 @@
+import os
+
+import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -11,6 +14,20 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 # from .routers.template import template_router
 from src import __name__, __version__
+from src.config import SentrySettings
+from src.logger import logger
+
+_environment = os.getenv("ENVIRONMENT", "production")
+_sentry_settings = SentrySettings()
+if _sentry_settings.SENTRY_API_DSN and _environment != "testing":
+    try:
+        sentry_sdk.init(
+            dsn=_sentry_settings.SENTRY_API_DSN,
+            send_default_pii=_sentry_settings.SEND_DEFAULT_PII,
+            environment=_environment,
+        )
+    except Exception as e:
+        logger.warning(f"Sentry initialization failed, continuing without it: {e}")
 
 app = FastAPI(
     title=__name__,

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -39,6 +39,7 @@ test = [
     "requests>=2.32.3",
     "coverage>=7.8.0",
     "datasets>=3.6.0",
+    "pytest-dotenv>=0.5.2",
 ]
 ocr-backend = [
     "httpx>=0.25.0",
@@ -47,6 +48,7 @@ ocr-backend = [
     "python-multipart==0.0.20",
     "prometheus-fastapi-instrumentator>=7.1.0",
     "python-keycloak>=5.7.0",
+    "sentry-sdk[fastapi]>=2.34.1",
 ]
 
 ocr-service-paddle = [
@@ -79,6 +81,7 @@ services = [
     "pynvml>=12.0.0",
     "pypandoc-binary>=1.15",
     "unstructured>=0.18.15",
+    "sentry-sdk[celery]>=2.34.1",
 ]
 
 migration = [
@@ -130,6 +133,10 @@ update_changelog_on_bump = true
 major_version_zero = true
 
 
+
+[tool.pytest.ini_options]
+env_override_existing_values = 1
+env_files = ["tests/.env.testing"]
 
 [tool.ruff]
 line-length = 120

--- a/apps/server/services/main.py
+++ b/apps/server/services/main.py
@@ -2,13 +2,28 @@ import os
 import json
 import traceback
 
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 from services.base.pipeline import Pipeline
+from src.config import SentrySettings
 from src.connector.broker_connector import celery_app, celery_config
 from src.logger import logger
 from src.schemas.task import TaskForm, TaskModel, TaskStatus, task_table
 from services.base.tracing import get_tracing_service
 from .factory import load_worker
+
+_sentry_settings = SentrySettings()
+if _sentry_settings.SENTRY_WORKER_DSN:
+    try:
+        sentry_sdk.init(
+            dsn=_sentry_settings.SENTRY_WORKER_DSN,
+            send_default_pii=_sentry_settings.SEND_DEFAULT_PII,
+            environment=os.getenv("ENVIRONMENT", "production"),
+            integrations=[CeleryIntegration()],
+        )
+    except Exception as e:
+        logger.warning(f"Sentry initialization failed, continuing without it: {e}")
 
 process_ocr: Pipeline = load_worker(name=os.environ["PROCESS_NAME"])
 
@@ -22,6 +37,14 @@ tracing = get_tracing_service(tracing_name=os.environ.get("TRACING_SERVICE", "lo
 @celery_app.task(name=os.environ["WORKER_NAME"], bind=True)
 def launch_task(self, task_info: dict):
     task = TaskModel.model_validate(json.loads(task_info))
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("task.id", task.id)
+        scope.set_tag("worker.name", os.environ["WORKER_NAME"])
+        scope.set_user({"id": task.user_id})
+        return _run_task(task)
+
+
+def _run_task(task: TaskModel) -> dict:
     try:
         with tracing.trace_context(trace_id=task.id, user_id=task.user_id, name=os.environ["WORKER_NAME"]):
             task = process_ocr.process(task=task)

--- a/apps/server/src/config/__init__.py
+++ b/apps/server/src/config/__init__.py
@@ -2,5 +2,6 @@ from .celery import CelerySettings
 from .ocr_model import OCRModelSettings
 from .redis import RedisSettings
 from .s3 import S3Settings
+from .sentry import SentrySettings
 
-__all__ = ["S3Settings", "RedisSettings", "OCRModelSettings", "CelerySettings"]
+__all__ = ["S3Settings", "RedisSettings", "OCRModelSettings", "CelerySettings", "SentrySettings"]

--- a/apps/server/src/config/sentry.py
+++ b/apps/server/src/config/sentry.py
@@ -1,0 +1,8 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SentrySettings(BaseSettings):
+    SENTRY_API_DSN: str = ""
+    SENTRY_WORKER_DSN: str = ""
+    SEND_DEFAULT_PII: bool = False
+    model_config = SettingsConfigDict(from_attributes=True, case_sensitive=True, env_file=".env", extra="allow")

--- a/apps/server/tests/.env.testing
+++ b/apps/server/tests/.env.testing
@@ -1,0 +1,1 @@
+ENVIRONMENT=testing

--- a/apps/server/uv.lock
+++ b/apps/server/uv.lock
@@ -2484,6 +2484,7 @@ ocr-backend = [
     { name = "prometheus-fastapi-instrumentator" },
     { name = "python-keycloak" },
     { name = "python-multipart" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 ocr-docling = [
@@ -2524,6 +2525,7 @@ services = [
     { name = "psutil" },
     { name = "pynvml" },
     { name = "pypandoc-binary" },
+    { name = "sentry-sdk", extra = ["celery"] },
     { name = "unstructured" },
 ]
 stress-test = [
@@ -2537,6 +2539,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-dotenv" },
     { name = "requests" },
     { name = "ruff" },
 ]
@@ -2587,6 +2590,7 @@ ocr-backend = [
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
     { name = "python-keycloak", specifier = ">=5.7.0" },
     { name = "python-multipart", specifier = "==0.0.20" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.34.1" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.35.0" },
 ]
 ocr-docling = [{ name = "docling", specifier = ">=2.47.1" }]
@@ -2623,6 +2627,7 @@ services = [
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pynvml", specifier = ">=12.0.0" },
     { name = "pypandoc-binary", specifier = ">=1.15" },
+    { name = "sentry-sdk", extras = ["celery"], specifier = ">=2.34.1" },
     { name = "unstructured", specifier = ">=0.18.15" },
 ]
 stress-test = [{ name = "locust", specifier = ">=2.34.1" }]
@@ -2634,6 +2639,7 @@ test = [
     { name = "pytest", specifier = "==8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", specifier = ">=0.11.5" },
 ]
@@ -3493,6 +3499,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/b0/cafee9c627c1bae228eb07c9977f679b3a7cb111b488307ab9594ba9e4da/pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732", size = 3782, upload-time = "2020-06-16T12:38:03.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/da/9da67c67b3d0963160e3d2cbc7c38b6fae342670cc8e6d5936644b2cf944/pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f", size = 3993, upload-time = "2020-06-16T12:38:01.139Z" },
+]
+
+[[package]]
 name = "python-bidi"
 version = "0.6.6"
 source = { registry = "https://pypi.org/simple" }
@@ -4129,6 +4148,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/96/c418c322730b385e81d4ab462e68dd48bb2dbda4d8efa17cad2ca468d9ac/semchunk-2.2.2.tar.gz", hash = "sha256:940e89896e64eeb01de97ba60f51c8c7b96c6a3951dfcf574f25ce2146752f52", size = 12271, upload-time = "2024-12-17T22:54:30.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/84/94ca7896c7df20032bcb09973e9a4d14c222507c0aadf22e89fa76bb0a04/semchunk-2.2.2-py3-none-any.whl", hash = "sha256:94ca19020c013c073abdfd06d79a7c13637b91738335f3b8cdb5655ee7cc94d2", size = 10271, upload-time = "2024-12-17T22:54:27.689Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/5d/a343201726150e05f2036eeb6e493e2e2f8bf8a66f5aa70f2f4ac96f9ca3/sentry_sdk-2.62.0.tar.gz", hash = "sha256:3c870b9f50d9fd15b58c817dbde1c7cfaa9fe3f05df0a4c6edd5571cb82f5491", size = 463986, upload-time = "2026-06-08T13:23:49.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/07/05440381627877aae223fd68f330df9b9fc6641d08bf65328b55235617a2/sentry_sdk-2.62.0-py3-none-any.whl", hash = "sha256:27f61d13a86c3c1648dec666dd5a64f79772dd6a84b446f11866601ecab24f6f", size = 490586, upload-time = "2026-06-08T13:23:47.486Z" },
+]
+
+[package.optional-dependencies]
+celery = [
+    { name = "celery" },
+]
+fastapi = [
+    { name = "fastapi" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Remontée des erreurs vers Sentry pour les 3 services OCR**

Branche `api`, `worker` et `frontend` sur Sentry pour la remontée d'erreurs ([issue 836](https://github.com/IA-Generative/mcr/issues/836)), en s'inspirant de l'intégration existante sur MCR.

### Backend (`apps/server`)

- Nouvelle classe `SentrySettings` (`src/config/sentry.py`) : `SENTRY_API_DSN` / `SENTRY_WORKER_DSN` avec valeur par défaut vide, `SEND_DEFAULT_PII` à `False`.
- `ocr_backend/main.py` : init Sentry avant la création de l'app, gardé par `if SENTRY_API_DSN and ENVIRONMENT != "testing"`.
- `services/main.py` : init au chargement du worker avec `CeleryIntegration`, et tags `task.id` / `worker.name` / `user.id` ajoutés sur chaque tâche via un scope dédié.
- Dépendances : `sentry-sdk[fastapi]` (groupe `ocr-backend`) et `sentry-sdk[celery]` (groupe `services`).

### Frontend (`apps/client`)

- Ajout de `@sentry/vue`.
- `main.ts` : init avant le `mount`, gardé sur la présence du DSN, `sendDefaultPii: false`.
- DSN et environnement lus via le pattern existant `window.VITE_* ?? import.meta.env.VITE_*` (`constants.ts`).

### Tests

- `pytest-dotenv` + `tests/.env.testing` (`ENVIRONMENT=testing`, chargé avec `env_override_existing_values`) pour garantir que les tests tournent sous l'environnement `testing` → le SDK ne s'initialise donc pas pendant les tests.