### PR TITLE
fix(ci): correct tracing test assertion and stabilize SDK tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,10 @@ generate-openapi: up-frontend  ## Génère la documentation OpenAPI
 	docker compose -f $(FRONTEND_COMPOSE_FILE) exec ocr_frontend pnpm run generate-openapi
 
 test-sdk: install-uv ## Test le SDK Python
-	docker compose -f docker-compose.yaml up -d && \
+	docker compose -f docker-compose.yaml up -d
 	cd sdk && \
 	uv sync --dev && \
-	uv run pytest -s --cov=ocr_sdk --cov-report=term-missing -ra -v --maxfail=0 tests || \
-	docker compose -f docker-compose.yaml down -v 
-	
+	uv run pytest -s --cov=ocr_sdk --cov-report=term-missing -ra -v --maxfail=0 tests; \
+	status=$$?; \
+	docker compose -f $(PWD)/docker-compose.yaml down -v; \
+	exit $$status

--- a/apps/server/tests/services/base/test_tracing.py
+++ b/apps/server/tests/services/base/test_tracing.py
@@ -349,6 +349,6 @@ def test_langfuse_tracing_service_trace_error_handling(mock_logger, mock_import)
     # Vérifier qu'un warning a été loggé
     mock_logger.warning.assert_called()
     warning_calls = [
-        call for call in mock_logger.warning.call_args_list if "Error managing Langfuse trace" in str(call)
+        call for call in mock_logger.warning.call_args_list if "Error creating Langfuse trace" in str(call)
     ]
     assert len(warning_calls) > 0

--- a/sdk/tests/ocr_sdk/conftest.py
+++ b/sdk/tests/ocr_sdk/conftest.py
@@ -1,0 +1,37 @@
+import time
+
+import httpx
+import pytest
+
+API_BASE_URL = "http://localhost:5000"
+
+
+@pytest.fixture(scope="session")
+def api_ready():
+    """Block until the API serves a healthy response.
+
+    `docker compose up -d` returns as soon as containers are created, not when
+    the API is accepting requests, so tests that hit it immediately can fail
+    with connection resets. Polling /api/health (which is 200 only when db,
+    redis and minio are all healthy) lets the tests wait for a real readiness
+    signal instead.
+    """
+
+    deadline = time.monotonic() + 90
+    last = None
+
+    while time.monotonic() < deadline:
+        try:
+            r = httpx.get(f"{API_BASE_URL}/api/health", timeout=5.0)
+
+            if r.status_code == 200 and r.json().get("status") == "healthy":
+                return
+
+            last = f"status={r.status_code} body={r.text[:200]}"
+
+        except httpx.TransportError as exc:
+            last = repr(exc)
+
+        time.sleep(2)
+
+    pytest.fail(f"API at {API_BASE_URL} not healthy within 90s. Last: {last}")

--- a/sdk/tests/ocr_sdk/test_client_sync.py
+++ b/sdk/tests/ocr_sdk/test_client_sync.py
@@ -15,7 +15,7 @@ def path_to_test_file() -> str:
     return str(path)
 
 
-def test_sync_client(path_to_test_file: str):
+def test_sync_client(path_to_test_file: str, api_ready):
     with SyncOCRClient(base_url="http://localhost:5000", api_key="default-api-key") as client:
         health = client.get_health()
         assert health.status == "healthy"
@@ -30,7 +30,7 @@ def test_sync_client(path_to_test_file: str):
 
 
 @pytest.mark.asyncio
-async def test_async_client(path_to_test_file: str):
+async def test_async_client(path_to_test_file: str, api_ready):
     async with AsyncOCRClient(base_url="http://localhost:5000", api_key="default-api-key") as client:
         health = await client.get_health()
         assert health.status == "healthy"

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "ocr-sdk"
-version = "0.1.2"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Corrections CI : test de tracing et fiabilité des tests SDK

## Changements

- **`apps/server/tests/services/base/test_tracing.py`** : correction de la chaîne attendue dans le test `test_langfuse_tracing_service_trace_error_handling`. Le test cherchait `"Error managing Langfuse trace"`, qui n'existe plus ; le code log désormais `"Error creating Langfuse trace"`. Le test passe à nouveau.

- **`sdk/tests/ocr_sdk/conftest.py`** (nouveau) : ajout d'un fixture `api_ready` qui interroge `/api/health` jusqu'à obtenir une réponse `200` saine (avec gestion des erreurs de connexion, délai max 90 s). Cela évite les échecs aléatoires (« connection reset ») dus à des tests lancés avant que l'API ne soit prête après `docker compose up -d`.

- **`sdk/tests/ocr_sdk/test_client_sync.py`** : les tests `test_sync_client` et `test_async_client` utilisent désormais le fixture `api_ready`.

- **`Makefile`** (cible `test-sdk`) : correction du teardown. Le `docker compose down -v` s'exécute maintenant toujours depuis la racine du dépôt (via `$(PWD)`), aussi bien en cas de succès que d'échec, tout en préservant le code de sortie de pytest.

- **`sdk/uv.lock`** : synchronisation de la version du paquet local `ocr-sdk` (`0.1.2` → `0.10.1`), effet de bord de `uv sync`.
