### PR TITLE
fix(tracing): rétablir le tracing Langfuse et couper l'exporter OTLP orphelin

### DIFF
--- a/apps/server/services/base/tracing.py
+++ b/apps/server/services/base/tracing.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 import time
 from datetime import datetime
 from src.logger import logger
@@ -60,11 +60,13 @@ class LangFuseTracingService(TracingService):
         """
         self.client = None
         self.is_langfuse = False
+        self._propagate_attributes = None
 
         try:
-            from langfuse import Langfuse
+            from langfuse import Langfuse, propagate_attributes
 
             self.client = Langfuse()
+            self._propagate_attributes = propagate_attributes
             self.is_langfuse = self.client.auth_check()
             if not self.is_langfuse:
                 logger.warning("Langfuse authentication failed. Tracing will be disabled.")
@@ -78,6 +80,7 @@ class LangFuseTracingService(TracingService):
             except Exception as e:
                 logger.warning(f"Failed to shut down Langfuse client: {e}")
             self.client = None
+            self._propagate_attributes = None
 
     @contextmanager
     def _trace_implementation(self, trace_id: str, **kwargs):
@@ -86,44 +89,49 @@ class LangFuseTracingService(TracingService):
             yield None
             return
 
-        trace = None
+        stack = ExitStack()
         try:
-            # Créer le trace Langfuse
-            trace_id = self.client.create_trace_id(seed=trace_id)
-            trace = self.client.update_current_generation(
-                name=kwargs.get("name", trace_id),
-                input=kwargs.get("input"),
-                metadata=kwargs.get("metadata", {}),
-                model=kwargs.get("model", "ocr-service"),
+            user_id = kwargs.get("user_id")
+            session_id = kwargs.get("session_id")
+            if user_id or session_id:
+                stack.enter_context(self._propagate_attributes(user_id=user_id, session_id=session_id))
+
+            trace = stack.enter_context(
+                self.client.start_as_current_observation(
+                    trace_context={"trace_id": self.client.create_trace_id(seed=trace_id)},
+                    name=kwargs.get("name", trace_id),
+                    as_type="generation",
+                    input=kwargs.get("input"),
+                    metadata=kwargs.get("metadata", {}),
+                    model=kwargs.get("model", "ocr-service"),
+                )
             )
         except Exception as e:
             logger.warning(f"Error creating Langfuse trace: {e}")
+            stack.close()
+            yield None
+            return
 
         try:
             yield trace
         finally:
-            # Mettre à jour le trace avec les données finales
-            if trace and self.client:
-                try:
-                    metadata = kwargs.get("metadata", {})
+            try:
+                metadata = kwargs.get("metadata", {})
+                trace.update(
+                    output=metadata,
+                    metadata=metadata,
+                    usage_details=kwargs.get("usage_details", {}),
+                    cost_details=kwargs.get("cost_details", {}),
+                    model=kwargs.get("model", "ocr-service"),
+                )
+            except Exception as e:
+                logger.warning(f"Error finalizing Langfuse trace: {e}")
 
-                    # Mettre à jour avec les métadonnées finales si possible
-                    trace.update(
-                        output=metadata,
-                        metadata=metadata,
-                        usage_details=kwargs.get("usage_details", {}),
-                        cost_details=kwargs.get("cost_details", {}),
-                        model=kwargs.get("model", "ocr-service"),
-                    )
-
-                    # Ajouter la durée comme score si disponible
-                    trace.end()
-
-                    # Forcer flush
-                    self.client.flush()
-
-                except Exception as e:
-                    logger.warning(f"Error finalizing Langfuse trace: {e}")
+            stack.close()
+            try:
+                self.client.flush()
+            except Exception as e:
+                logger.warning(f"Error flushing Langfuse trace: {e}")
 
 
 def get_tracing_service(tracing_name: str) -> TracingService:

--- a/apps/server/services/base/tracing.py
+++ b/apps/server/services/base/tracing.py
@@ -58,6 +58,9 @@ class LangFuseTracingService(TracingService):
         """
         Initialise le service de traçage Langfuse.
         """
+        self.client = None
+        self.is_langfuse = False
+
         try:
             from langfuse import Langfuse
 
@@ -67,8 +70,14 @@ class LangFuseTracingService(TracingService):
                 logger.warning("Langfuse authentication failed. Tracing will be disabled.")
         except Exception as e:
             logger.warning(f"Failed to initialize Langfuse client: {e}. Tracing will be disabled.")
-            self.client = None
             self.is_langfuse = False
+
+        if not self.is_langfuse and self.client is not None:
+            try:
+                self.client.shutdown()
+            except Exception as e:
+                logger.warning(f"Failed to shut down Langfuse client: {e}")
+            self.client = None
 
     @contextmanager
     def _trace_implementation(self, trace_id: str, **kwargs):

--- a/apps/server/tests/services/base/test_tracing.py
+++ b/apps/server/tests/services/base/test_tracing.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, Mock, patch
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 try:
     import langfuse  # noqa: F401
@@ -169,42 +169,140 @@ def test_langfuse_tracing_service_trace_disabled(mock_import):
 
     # Vérifier qu'aucune méthode Langfuse n'a été appelée
     mock_client.create_trace_id.assert_not_called()
-    mock_client.start_generation.assert_not_called()
+    mock_client.start_as_current_observation.assert_not_called()
+
+
+def _langfuse_import_side_effect(mock_client):
+    """Expose un faux module langfuse via builtins.__import__."""
+    mock_module = MagicMock()
+    mock_module.Langfuse.return_value = mock_client
+    mock_module.propagate_attributes.return_value = nullcontext()
+
+    def import_side_effect(name, *args, **kwargs):
+        if name == "langfuse":
+            return mock_module
+        return __import__(name, *args, **kwargs)
+
+    return import_side_effect, mock_module
+
+
+def _enabled_client():
+    """Client Langfuse mocké dont l'observation est un context manager."""
+    mock_client = MagicMock()
+    mock_client.auth_check.return_value = True
+    mock_client.create_trace_id.return_value = "generated_trace_id"
+    return mock_client
 
 
 @patch("builtins.__import__")
 @patch("services.base.tracing.logger")
-def test_langfuse_tracing_service_trace_enabled(mock_logger, mock_import):
-    """Test LangFuseTracingService trace when enabled"""
-    mock_langfuse_class = Mock()
-    mock_client = Mock()
-    mock_client.auth_check.return_value = True
-    mock_trace = Mock()
-    mock_client.create_trace_id.return_value = "generated_trace_id"
-    mock_client.update_current_generation.return_value = mock_trace
-    mock_langfuse_class.return_value = mock_client
+def test_langfuse_tracing_service_opens_and_closes_an_observation(mock_logger, mock_import):
+    """Une tâche tracée doit ouvrir puis fermer une observation Langfuse.
 
-    def import_side_effect(name, *args, **kwargs):
-        if name == "langfuse":
-            mock_module = Mock()
-            mock_module.Langfuse = mock_langfuse_class
-            return mock_module
-        return __import__(name, *args, **kwargs)
-
-    mock_import.side_effect = import_side_effect
+    C'est l'invariant métier : sans observation ouverte, Langfuse n'enregistre rien.
+    """
+    mock_client = _enabled_client()
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+    observation = mock_client.start_as_current_observation.return_value
 
     service = LangFuseTracingService()
-    trace_id = "test_trace"
 
-    with service.trace_context(trace_id, name="test", input={"test": "data"}):
+    with service.trace_context("test_trace", name="test", input={"test": "data"}):
         pass
 
-    # Vérifier que les méthodes Langfuse ont été appelées
-    mock_client.create_trace_id.assert_called_once_with(seed=trace_id)
-    mock_client.update_current_generation.assert_called_once()
-    mock_trace.update.assert_called_once()
-    mock_trace.end.assert_called_once()
+    mock_client.create_trace_id.assert_called_once_with(seed="test_trace")
+    mock_client.start_as_current_observation.assert_called_once()
+    call_kwargs = mock_client.start_as_current_observation.call_args.kwargs
+    assert call_kwargs["trace_context"] == {"trace_id": "generated_trace_id"}
+    assert call_kwargs["name"] == "test"
+    assert call_kwargs["as_type"] == "generation"
+    assert call_kwargs["input"] == {"test": "data"}
+
+    observation.__enter__.assert_called_once()
+    observation.__exit__.assert_called_once()
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_yields_the_observation(mock_logger, mock_import):
+    """_trace_implementation doit exposer l'observation ouverte, pas None."""
+    mock_client = _enabled_client()
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+    observation = mock_client.start_as_current_observation.return_value
+
+    service = LangFuseTracingService()
+
+    with service._trace_implementation("test_trace", name="test") as yielded:
+        assert yielded is observation.__enter__.return_value
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_records_final_metadata(mock_logger, mock_import):
+    """La durée et le statut calculés dans trace_context doivent finir sur l'observation."""
+    mock_client = _enabled_client()
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+    trace = mock_client.start_as_current_observation.return_value.__enter__.return_value
+
+    service = LangFuseTracingService()
+
+    with service.trace_context("test_trace", name="test"):
+        pass
+
+    trace.update.assert_called_once()
+    metadata = trace.update.call_args.kwargs["metadata"]
+    assert metadata["status"] == "completed"
+    assert "duration_seconds" in metadata
     mock_client.flush.assert_called_once()
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_propagates_user_id(mock_logger, mock_import):
+    """user_id est passé par services/main.py : il doit atteindre la trace Langfuse."""
+    mock_client = _enabled_client()
+    mock_import.side_effect, mock_module = _langfuse_import_side_effect(mock_client)
+
+    service = LangFuseTracingService()
+
+    with service.trace_context("test_trace", name="test", user_id="user-42", session_id="session-7"):
+        pass
+
+    mock_module.propagate_attributes.assert_called_once_with(user_id="user-42", session_id="session-7")
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_closes_observation_on_business_error(mock_logger, mock_import):
+    """Une erreur métier remonte, mais l'observation doit quand même être fermée."""
+    mock_client = _enabled_client()
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+    observation = mock_client.start_as_current_observation.return_value
+
+    service = LangFuseTracingService()
+
+    with pytest.raises(ValueError, match="boom"):
+        with service.trace_context("test_trace", name="test"):
+            raise ValueError("boom")
+
+    observation.__exit__.assert_called_once()
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_survives_finalization_error(mock_logger, mock_import):
+    """Un échec côté Langfuse ne doit jamais faire échouer la tâche OCR."""
+    mock_client = _enabled_client()
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+    trace = mock_client.start_as_current_observation.return_value.__enter__.return_value
+    trace.update.side_effect = Exception("Langfuse down")
+
+    service = LangFuseTracingService()
+
+    with service.trace_context("test_trace", name="test"):
+        pass
+
+    assert any("Error finalizing Langfuse trace" in str(call) for call in mock_logger.warning.call_args_list)
 
 
 @patch("services.base.tracing.time")
@@ -324,19 +422,6 @@ def test_process_error_still_propagated():
     with pytest.raises(ValueError, match="Test error"):
         with service.trace_context(trace_id):
             raise ValueError("Test error")
-
-
-def _langfuse_import_side_effect(mock_client):
-    """Expose un faux module langfuse via builtins.__import__."""
-    mock_module = MagicMock()
-    mock_module.Langfuse.return_value = mock_client
-
-    def import_side_effect(name, *args, **kwargs):
-        if name == "langfuse":
-            return mock_module
-        return __import__(name, *args, **kwargs)
-
-    return import_side_effect, mock_module
 
 
 @patch("builtins.__import__")

--- a/apps/server/tests/services/base/test_tracing.py
+++ b/apps/server/tests/services/base/test_tracing.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from contextlib import contextmanager
 
 try:
@@ -118,7 +118,7 @@ def test_langfuse_tracing_service_init_auth_fail(mock_logger, mock_import):
 
     service = LangFuseTracingService()
 
-    assert service.client == mock_client
+    assert service.client is None
     assert service.is_langfuse is False
     mock_client.auth_check.assert_called_once()
     mock_logger.warning.assert_called_once_with("Langfuse authentication failed. Tracing will be disabled.")
@@ -324,6 +324,68 @@ def test_process_error_still_propagated():
     with pytest.raises(ValueError, match="Test error"):
         with service.trace_context(trace_id):
             raise ValueError("Test error")
+
+
+def _langfuse_import_side_effect(mock_client):
+    """Expose un faux module langfuse via builtins.__import__."""
+    mock_module = MagicMock()
+    mock_module.Langfuse.return_value = mock_client
+
+    def import_side_effect(name, *args, **kwargs):
+        if name == "langfuse":
+            return mock_module
+        return __import__(name, *args, **kwargs)
+
+    return import_side_effect, mock_module
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_shuts_down_client_when_auth_returns_false(mock_logger, mock_import):
+    """Le constructeur Langfuse a déjà démarré un exporter OTLP en tâche de fond.
+
+    Sans shutdown explicite, cet exporter continue d'émettre vers Langfuse et chaque
+    batch échoue en 401 — c'est la source des 19k événements Sentry OCR-WORKER-T.
+    """
+    mock_client = MagicMock()
+    mock_client.auth_check.return_value = False
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+
+    service = LangFuseTracingService()
+
+    mock_client.shutdown.assert_called_once()
+    assert service.client is None
+    assert service.is_langfuse is False
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_shuts_down_client_when_auth_raises(mock_logger, mock_import):
+    """auth_check() lève UnauthorizedError sur des identifiants invalides : même exigence."""
+    mock_client = MagicMock()
+    mock_client.auth_check.side_effect = Exception("UnauthorizedError")
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+
+    service = LangFuseTracingService()
+
+    mock_client.shutdown.assert_called_once()
+    assert service.client is None
+    assert service.is_langfuse is False
+
+
+@patch("builtins.__import__")
+@patch("services.base.tracing.logger")
+def test_langfuse_tracing_service_survives_shutdown_error(mock_logger, mock_import):
+    """Un shutdown qui échoue ne doit pas empêcher le worker de démarrer."""
+    mock_client = MagicMock()
+    mock_client.auth_check.return_value = False
+    mock_client.shutdown.side_effect = Exception("shutdown failed")
+    mock_import.side_effect, _ = _langfuse_import_side_effect(mock_client)
+
+    service = LangFuseTracingService()
+
+    assert service.client is None
+    assert service.is_langfuse is False
 
 
 @patch("builtins.__import__")


### PR DESCRIPTION
## Contexte

L'issue Sentry [OCR-WORKER-T](https://sentry-dev.mirai-hp.cpin.numerique-interieur.com/organizations/sentry/issues/OCR-WORKER-T) remonte 19 613 événements en 15 jours (~1 310/jour, ~18/min répartis uniformément sur les 5 pods), tous en `production` : `Failed to export span batch code: 401` depuis l'exporter OTLP de Langfuse. Aucun impact utilisateur — les tâches OCR se terminent normalement — mais ces événements représentent ~99,9 % du volume Sentry du projet `ocr-worker` et noient les vraies erreurs.

L'investigation a mis au jour deux défauts distincts dans `services/base/tracing.py` :

- **Le tracing Langfuse n'enregistre plus rien depuis le 2026-07-05.** Le commit `f272783` a remplacé `start_generation()` (qui ouvre une observation) par `update_current_generation()`, qui retourne `None` et ne fait rien en l'absence de span actif. Le `user_id` transmis par `services/main.py` était perdu au passage.
- **Un `auth_check()` en échec ne coupait pas l'exporter.** Le constructeur `Langfuse()` enregistre un `TracerProvider` global et démarre un exporter OTLP en tâche de fond. Le code se contentait de `self.client = None` : l'exporter survivait et continuait d'émettre, chaque batch échouant en 401.

Le second défaut est la source des événements Sentry ; le premier explique pourquoi la panne est passée inaperçue — la fonctionnalité était déjà morte.

Les identifiants Langfuse de production ont été régénérés en parallèle (à reporter dans Vault, `mirai/kv/prod/ocr`). Les deux endpoints ont été vérifiés avec les nouvelles clés : `GET /api/public/projects` → 200, `POST /api/public/otel/v1/traces` → 200, et le même POST sans authentification → 401. Ce dernier contrôle écarte l'hypothèse d'un ingress qui supprimerait l'en-tête `Authorization` sur la route OTel.

## Changements

- `LangFuseTracingService.__init__` appelle `client.shutdown()` quand l'authentification échoue, sur les deux chemins possibles (`auth_check()` renvoie `False` **ou** lève une exception), avant de remettre `client` à `None`. Plus d'exporter orphelin.
- `_trace_implementation` ouvre une véritable observation via `start_as_current_observation(as_type="generation")` autour du `yield`. L'observation est fermée **avant** le `flush()`, sinon le span n'est pas terminé et n'est pas exporté.
- `user_id` / `session_id` de nouveau propagés à la trace, via `propagate_attributes()`.
- Les erreurs Langfuse restent cantonnées : création, finalisation, flush et shutdown sont chacun protégés, une tâche OCR ne peut pas échouer à cause du tracing.

## Notes pour la review

- Les deux commits sont indépendants et vérifiés séparément (tests + ruff verts à chaque commit) : la branche reste bisectable.
- Les tests portent sur les invariants métier plutôt que sur les appels : une tâche tracée ouvre **et ferme** une observation ; un échec d'authentification arrête l'exporter ; une erreur Langfuse ne fait jamais échouer la tâche.
- Vérification hors mocks : le fichier a été exécuté tel quel contre le vrai SDK langfuse 4.12.0 et un faux serveur Langfuse. Avant correctif, 3 tâches produisaient 0 export ; après, 3 tâches → 3 exports, et avec des identifiants invalides → 0 export (client arrêté).
- `flush()` reste appelé à chaque tâche (comportement d'origine conservé) : c'est un aller-retour HTTP par tâche OCR, à réévaluer si la latence des tâches courtes devient un sujet.
- Point ouvert, sans incidence sur ce correctif : la bibliothèque tierce qui alimentait l'exporter orphelin n'est pas identifiée (`langsmith`, tiré par `langchain-community`, est le candidat le plus sérieux). Une fois les exports fonctionnels, ces spans apparaîtront dans le projet Langfuse et se laisseront identifier.
- Ce correctif seul ne suffit pas à rétablir le tracing : il faut aussi les nouvelles clés dans Vault et un redémarrage des pods. Sans elles, l'exporter est simplement arrêté proprement — ce qui suffit à éteindre l'issue Sentry.
